### PR TITLE
Update: the version of Eigen, because version 3.3 can not be compiled…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
-set(EIGEN_VERSION 3.3)
+set(EIGEN_VERSION 3.4)
 find_package(Eigen3 ${EIGEN_VERSION} QUIET)
 if(NOT EIGEN3_FOUND)
   set(BUILD_TESTING OFF CACHE INTERNAL "")


### PR DESCRIPTION
Update the version from 3.3 to 3.4 to compile this library using clang 13 and c++20 option.
The reason of why it is faile to compile the library is that `typename std::result_of` is removed from clang 13.  